### PR TITLE
GPII-4014:  Scripts for deleting expired access tokens

### DIFF
--- a/scripts/deleteExpiredAccessTokens.js
+++ b/scripts/deleteExpiredAccessTokens.js
@@ -176,10 +176,10 @@ gpii.accessTokens.migrateRecursive = function (options) {
         },
         function (error) {
             if (error.errorCode === "GPII-NO-MORE-DOCS") {
-                console.log("Exiting: " + error.message);
+                console.log("Done: " + error.message);
                 process.exit(0);
             } else {
-                console.log(error);
+                console.log("Exiting with error: " + error);
                 process.exit(1);
             }
         }


### PR DESCRIPTION
@cindly this modification changes `deleteRecursive()` to return a `fluid.promise` so as to not call `process.exit()` directly.  That is then handled by the caller, namely, `deleteAccessTokens()`.  This addresses one of @amb26's [review comments](https://github.com/GPII/universal/pull/810#discussion_r312097368).